### PR TITLE
Bump premise-selection

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "572eac33bc7e3693e2c968bf6c2948893fc3bf7c",
+   "rev": "3a9d1c489d016eafc75fcc37f5aa5d3b1205dbee",
    "name": "«premise-selection»",
    "manifestFile": "lake-manifest.json",
    "inputRev": "v4.15.0",


### PR DESCRIPTION
This new version fixes a bug: specifically previously the `curl` to the server on some Linux machines could only handle e.g. < 131072 bytes of data. This data is changed to stdin instead of argv and this issue is now resolved.